### PR TITLE
Multitriggerfix

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 #include <QDateTime>
 #include <QLoggingCategory>
 
-const QString APP_VERSION = "0.45";
+const QString APP_VERSION = "0.46";
 
 void qtLogger(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {

--- a/src/rf8000device.h
+++ b/src/rf8000device.h
@@ -2,6 +2,7 @@
 #define RF8000DEVICE_H
 
 #include "abstractpmdevice.h"
+#include <QTimer>
 
 class Rf8000Device : public AbstractPMDevice
 {
@@ -20,12 +21,14 @@ public:
 private slots:
     void onSerialPortNewData(const QString &data);
     void onSerialPortError(const QString &error);
+    void sendBufferedCommand();
 
 private:
     SerialPortInterface *m_serialPort;
     quint64 m_currentFrequencyHz = 1000000;
     double m_currentOffsetDb = 0.0;
     bool m_isPositiveOffset = true;
+    QTimer *m_commandTimer;
 
     void sendCommand();
 };


### PR DESCRIPTION
This pull request updates the application version and introduces a command buffering mechanism to the Rf8000Device class. The main goal is to ensure commands are sent with a short delay, improving serial port communication reliability.

**Version update:**

* Incremented the application version from 0.45 to 0.46 in main.cpp to reflect the new changes.

**Command buffering and timer integration:**

* Added a QTimer member (m_commandTimer) to Rf8000Device, initialized as single-shot with a 300ms interval, and connected its timeout signal to the new sendBufferedCommand() slot. [[1]](diffhunk://#diff-87f3766b0c7a7fe44709e589b72a5d2f17367716b660e2ebd5722a0e74e44355R12-R16) [[2]](diffhunk://#diff-8aad66f37708b3c2155c28afe0018283be70d52f5ea5aea8cc9225fec828c5a9R5) [[3]](diffhunk://#diff-8aad66f37708b3c2155c28afe0018283be70d52f5ea5aea8cc9225fec828c5a9R24-R31)
* Modified the sendCommand() method to start the timer instead of sending immediately, and implemented sendBufferedCommand() to send the command when the timer fires, ensuring the serial port is open before sending. [[1]](diffhunk://#diff-87f3766b0c7a7fe44709e589b72a5d2f17367716b660e2ebd5722a0e74e44355R50-R55) [[2]](diffhunk://#diff-8aad66f37708b3c2155c28afe0018283be70d52f5ea5aea8cc9225fec828c5a9R24-R31)
* Stopped the command timer in disconnectDevice() to prevent pending commands from being sent after disconnecting.