### PR TITLE
Some calibration fixes

### DIFF
--- a/src/calibrationmanager.cpp
+++ b/src/calibrationmanager.cpp
@@ -91,7 +91,6 @@ CalibrationManager::CalibrationManager(QWidget *parent) :
 
     ui->calibrateSelected_progressBar->setVisible(false);
     ui->calibrateSelected_progressBar->setTextVisible(false);
-    ui->pickAverageButton->setEnabled(false);
 
     setupPlot();
     onStartFreqChanged(ui->startFreqSpinBox->value());
@@ -109,6 +108,23 @@ CalibrationManager::CalibrationManager(QWidget *parent) :
             this, &CalibrationManager::onTinySaConnectClicked);
     connect(ui->calibrateAllButton,  &QPushButton::clicked,
             this, &CalibrationManager::onCalibrateAllClicked);
+    // Both calibrate buttons are checkable: their OR-ed checked state is
+    // "calibration in flight", and that drives the table grey-out via the
+    // refreshLock lambda below. Sweep-start/-end paths only toggle the
+    // appropriate button; the text + tables follow automatically.
+    ui->calibrateAllButton->setCheckable(true);
+    ui->pickAverageButton->setCheckable(true);
+    auto refreshLock = [this](bool) {
+        const bool busy = ui->calibrateAllButton->isChecked()
+                       || ui->pickAverageButton->isChecked();
+        ui->tableView->setDisabled(busy);
+        if (m_advancedTableView) m_advancedTableView->setDisabled(busy);
+    };
+    connect(ui->calibrateAllButton, &QPushButton::toggled, this, refreshLock);
+    connect(ui->pickAverageButton,  &QPushButton::toggled, this, refreshLock);
+    connect(ui->calibrateAllButton, &QPushButton::toggled, this, [this](bool busy) {
+        ui->calibrateAllButton->setText(busy ? tr("Cancel calibration") : tr("Calibrate All"));
+    });
 
     // Default UI shape: Simple, Auto off, TinySa subgroup hidden.
     applyModeUi(CalibrationModel::Mode::Simple);
@@ -219,10 +235,15 @@ CalibrationManager::CalibrationManager(QWidget *parent) :
                     if (current.column() >= 0 && current.column() < axis.size()) {
                         mirrorRefSpinbox(axis[current.column()]);
                     }
-                    ui->pickAverageButton->setEnabled(true);
                 }
+                refreshButtonEnabledState();
                 updateAdvancedColumnChart();
             });
+
+    // Set the initial enabled state once everything is wired up.
+    // m_pmConnected = false, m_tinySaConnected = false, no selection yet,
+    // so both calibrate buttons start disabled.
+    refreshButtonEnabledState();
 }
 
 CalibrationManager::~CalibrationManager()
@@ -528,11 +549,15 @@ void CalibrationManager::onStepUnitChanged(const QString &newUnit)
 void CalibrationManager::onDeviceConnectionStateChanged(bool connected)
 {
     qDebug() << Q_FUNC_INFO << "Connected:" << connected;
+    m_pmConnected = connected;
     if (!connected) {
         m_samplesToTake = 0;
         m_measurements.clear();
         ui->calibrateSelected_progressBar->setVisible(false);
+        ui->pickAverageButton->setChecked(false);
+        ui->calibrateAllButton->setChecked(false);
     }
+    refreshButtonEnabledState();
 }
 
 void CalibrationManager::onNewMeasurement(double dbmValue)
@@ -579,6 +604,7 @@ void CalibrationManager::onNewMeasurement(double dbmValue)
             m_samplesToTake = 0;
 
             ui->calibrateSelected_progressBar->setVisible(false);
+            ui->pickAverageButton->setChecked(false);
         }
 }
 
@@ -636,7 +662,7 @@ void CalibrationManager::ontable_clicked(const QModelIndex &index)
 
     m_selectedIndex = index;
     double freq = m_model->data(m_model->index(index.row(), CalibrationModel::Frequency)).toDouble();
-    ui->pickAverageButton->setEnabled(true);
+    refreshButtonEnabledState();
     highlightPoint(index);
     emit frequencySelected(freq);
 }
@@ -644,6 +670,13 @@ void CalibrationManager::ontable_clicked(const QModelIndex &index)
 void CalibrationManager::onpickAverageButton_clicked()
 {
     qDebug()<<Q_FUNC_INFO;
+    // Re-click guard. The button is checkable so Qt auto-toggles its
+    // checked state on each click. If a calibration is already running,
+    // ignore the click and force the "running" indicator back on.
+    if (m_samplesToTake > 0 || m_autoCurrentRow >= 0) {
+        ui->pickAverageButton->setChecked(true);
+        return;
+    }
     if (m_model->mode() == CalibrationModel::Mode::Advanced) {
         const QModelIndex curr = m_advancedTableView
                                      ? m_advancedTableView->currentIndex()
@@ -651,11 +684,13 @@ void CalibrationManager::onpickAverageButton_clicked()
         if (!curr.isValid()) {
             QMessageBox::information(this, tr("No Selection"),
                                      tr("Please pick a cell in the Advanced grid first."));
+            ui->pickAverageButton->setChecked(false);
             return;
         }
         if (ui->autoCalibrationCheckBox->isChecked() && !m_tinySaConnected) {
             QMessageBox::information(this, tr("TinySa not connected"),
                                      tr("Please connect the TinySa first."));
+            ui->pickAverageButton->setChecked(false);
             return;
         }
         m_manualAdvancedRow = curr.row();
@@ -679,6 +714,7 @@ void CalibrationManager::onpickAverageButton_clicked()
         {
             qDebug() << Q_FUNC_INFO << "Aborting: No item selected in table.";
             QMessageBox::information(this, tr("No Selection"), tr("Please select a frequency in the table first."));
+            ui->pickAverageButton->setChecked(false);
             return;
         }
     // Auto path: drive TinySa to (selectedFreq, RefPower) and let the
@@ -688,6 +724,7 @@ void CalibrationManager::onpickAverageButton_clicked()
         if (!m_tinySaConnected) {
             QMessageBox::information(this, tr("TinySa not connected"),
                                      tr("Please connect the TinySa first."));
+            ui->pickAverageButton->setChecked(false);
             return;
         }
         startAutoCellForCurrentSelection();
@@ -1004,6 +1041,10 @@ void CalibrationManager::onModeChanged()
     m_model->setMode(mode);
     applyModeUi(mode);
     persistMode(mode);
+    // Selection semantics differ per mode (m_selectedIndex vs the
+    // advanced grid's currentIndex), so the calibrate buttons need a
+    // re-evaluation after a mode flip.
+    refreshButtonEnabledState();
 }
 
 void CalibrationManager::applyModeUi(CalibrationModel::Mode mode)
@@ -1081,8 +1122,7 @@ void CalibrationManager::onAutoCheckBoxToggled(bool checked)
     ui->tinySaSourceGroupBox->setVisible(checked
                                          && m_model->mode() != CalibrationModel::Mode::Disabled);
     persistAuto(checked);
-    // Calibrate All only makes sense once TinySa is connected.
-    ui->calibrateAllButton->setEnabled(checked && m_tinySaConnected);
+    refreshButtonEnabledState();
 }
 
 void CalibrationManager::persistAuto(bool autoOn)
@@ -1153,7 +1193,7 @@ void CalibrationManager::onTinySaConnected()
     ui->tinySaStatusLabel->setText(
         tr("connected: %1 -- connect TinySa RF OUT to the power meter input via coax")
             .arg(m_tinySa->portName()));
-    ui->calibrateAllButton->setEnabled(true);
+    refreshButtonEnabledState();
 }
 
 void CalibrationManager::onTinySaDisconnected()
@@ -1161,7 +1201,7 @@ void CalibrationManager::onTinySaDisconnected()
     m_tinySaConnected = false;
     ui->tinySaConnectButton->setText(tr("Connect"));
     ui->tinySaStatusLabel->setText(tr("not connected"));
-    ui->calibrateAllButton->setEnabled(false);
+    refreshButtonEnabledState();
     // If a Calibrate All loop is in flight, abort cleanly.
     const bool wasAuto = (m_autoCurrentRow >= 0) || m_autoSequence;
     m_autoQueue.clear();
@@ -1170,7 +1210,8 @@ void CalibrationManager::onTinySaDisconnected()
     m_autoSequence = false;
     if (m_autoWatchdog) m_autoWatchdog->stop();
     if (wasAuto) mirrorRefSpinbox(m_autoAskedRefDbm);
-    ui->calibrateAllButton->setText(tr("Calibrate All"));
+    ui->calibrateAllButton->setChecked(false);
+    ui->pickAverageButton->setChecked(false);
 }
 
 void CalibrationManager::onTinySaError(const QString &msg)
@@ -1231,6 +1272,7 @@ void CalibrationManager::onAutoCellTimeout()
         dispatchNextAutoCell();
     } else {
         mirrorRefSpinbox(m_autoAskedRefDbm);
+        ui->pickAverageButton->setChecked(false);
     }
 }
 
@@ -1262,6 +1304,7 @@ void CalibrationManager::onCalibrateAllClicked()
     if (!m_tinySaConnected) {
         QMessageBox::information(this, tr("TinySa not connected"),
                                  tr("Please connect the TinySa first."));
+        ui->calibrateAllButton->setChecked(false);
         return;
     }
     m_autoQueue.clear();
@@ -1272,10 +1315,11 @@ void CalibrationManager::onCalibrateAllClicked()
         enqueueAdvancedSweep();
         if (m_autoQueue.isEmpty()) {
             ui->tinySaStatusLabel->setText(tr("nothing to calibrate"));
+            ui->calibrateAllButton->setChecked(false);
             return;
         }
         m_autoSequence = true;
-        ui->calibrateAllButton->setText(tr("Cancel calibration"));
+        ui->calibrateAllButton->setChecked(true);
         dispatchNextAutoCell();
         return;
     }
@@ -1292,10 +1336,11 @@ void CalibrationManager::onCalibrateAllClicked()
     }
     if (m_autoQueue.isEmpty()) {
         ui->tinySaStatusLabel->setText(tr("nothing to calibrate"));
+        ui->calibrateAllButton->setChecked(false);
         return;
     }
     m_autoSequence = true;
-    ui->calibrateAllButton->setText(tr("Cancel calibration"));
+    ui->calibrateAllButton->setChecked(true);
     dispatchNextAutoCell();
 }
 
@@ -1313,7 +1358,7 @@ void CalibrationManager::cancelAutoSweep()
     // Turn the TinySa output off so the user isn't left with a live
     // signal at the last clamped freq/level after cancelling.
     if (m_tinySa && m_tinySaConnected) m_tinySa->pauseOutput();
-    ui->calibrateAllButton->setText(tr("Calibrate All"));
+    ui->calibrateAllButton->setChecked(false);
     ui->tinySaStatusLabel->setText(tr("calibration cancelled"));
 }
 
@@ -1351,6 +1396,39 @@ void CalibrationManager::mirrorRefSpinbox(double dbm)
     ui->referencePowerSpinBox->setValue(dbm);
 }
 
+void CalibrationManager::refreshButtonEnabledState()
+{
+    const bool autoOn = ui->autoCalibrationCheckBox->isChecked();
+    const bool hasSelection =
+        (m_model->mode() == CalibrationModel::Mode::Advanced)
+            ? (m_advancedTableView && m_advancedTableView->currentIndex().isValid())
+            : m_selectedIndex.isValid();
+    // Calibrate Selected needs the power meter (for samples) and a target
+    // row/cell. Auto mode also needs the TinySa source.
+    ui->pickAverageButton->setEnabled(
+        m_pmConnected && hasSelection && (!autoOn || m_tinySaConnected));
+    // Calibrate All always uses the auto sweep path: needs PM + TinySa,
+    // plus the Auto checkbox (legacy gate kept for parity).
+    ui->calibrateAllButton->setEnabled(
+        m_pmConnected && m_tinySaConnected && autoOn);
+}
+
+void CalibrationManager::scrollToCurrentAutoCell()
+{
+    if (m_autoCurrentRow < 0) return;
+    if (m_autoMode == CalibrationModel::Mode::Advanced
+        && m_advancedTableView && m_advancedAdapter) {
+        const QModelIndex idx = m_advancedAdapter->index(
+            m_autoCurrentRow, qMax(0, m_autoCurrentCol));
+        m_advancedTableView->setCurrentIndex(idx);
+        m_advancedTableView->scrollTo(idx, QAbstractItemView::PositionAtCenter);
+    } else {
+        ui->tableView->selectRow(m_autoCurrentRow);
+        ui->tableView->scrollTo(m_model->index(m_autoCurrentRow, 0),
+                                QAbstractItemView::PositionAtCenter);
+    }
+}
+
 void CalibrationManager::dispatchNextAutoCell()
 {
     if (m_autoQueue.isEmpty()) {
@@ -1362,7 +1440,7 @@ void CalibrationManager::dispatchNextAutoCell()
         // from the value they typed, not from whatever the last cell
         // clamped to.
         mirrorRefSpinbox(m_autoAskedRefDbm);
-        ui->calibrateAllButton->setText(tr("Calibrate All"));
+        ui->calibrateAllButton->setChecked(false);
         ui->tinySaStatusLabel->setText(tr("calibration sweep done"));
         return;
     }
@@ -1389,6 +1467,11 @@ void CalibrationManager::dispatchNextAutoCell()
         freqMHz = m_model->getPoints()[m_autoCurrentRow].frequencyMHz;
     }
     const double freqHz = freqMHz * 1e6;
+
+    // Scroll the cell being calibrated into view so the user can watch
+    // sweep progress; the tables are already greyed out via the
+    // calibrateAllButton.toggled connection set up in the ctor.
+    scrollToCurrentAutoCell();
 
     // Tune the DUT to this row's freq -- same signal Calibrate Selected
     // emits when the user clicks a row in the table.
@@ -1457,6 +1540,7 @@ void CalibrationManager::startAutoCellForCurrentSelection()
     m_autoCurrentRow = m_selectedIndex.row();
     m_autoCurrentCol = -1;
     m_autoMode = CalibrationModel::Mode::Simple;
+    scrollToCurrentAutoCell();
     const double freqMHz = m_model->getPoints()[m_autoCurrentRow].frequencyMHz;
     const double freqHz  = freqMHz * 1e6;
     // Tune the DUT to the row's freq (same signal the table click sends
@@ -1521,6 +1605,7 @@ void CalibrationManager::onAutoSampleArrived(double dbmValue)
         // Single-cell run done: put the user-asked refPower back in the
         // spinbox.
         mirrorRefSpinbox(m_autoAskedRefDbm);
+        ui->pickAverageButton->setChecked(false);
     }
 }
 

--- a/src/calibrationmanager.h
+++ b/src/calibrationmanager.h
@@ -120,6 +120,12 @@ private:
     void dispatchNextAutoCell();
     void onAutoSampleArrived(double dbmValue);
 
+    // Programmatically selects + scrolls the currently-dispatching auto
+    // cell into view so the user can watch sweep progress. The tables'
+    // greyed-out state is wired in the ctor via calibrateAllButton.toggled,
+    // not via a helper called from each state-change site.
+    void scrollToCurrentAutoCell();
+
     Ui::CalibrationManager *ui;
     CalibrationModel *m_model;
     QVector<double> m_measurements;
@@ -135,6 +141,12 @@ private:
     // lazily on first Connect click.
     TinySaSourceController *m_tinySa = nullptr;
     bool m_tinySaConnected = false;
+    // Mirror of the power-meter device's connected state, fed by
+    // onDeviceConnectionStateChanged. Both calibrate buttons are gated
+    // on this via refreshButtonEnabledState() -- without a meter there
+    // are no samples to average, so calibration must not start.
+    bool m_pmConnected = false;
+    void refreshButtonEnabledState();
 
     // Per-device persistence anchor; empty string means "global default".
     QString m_activeDeviceId;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1145,6 +1145,7 @@ void MainWindow::onDeviceConnected()
     // table inline; the lookup table is stable now that we're Ready.
     if (m_calibrationManager) {
         m_calibrationManager->setActiveConceptRfDevice(cdev);
+        m_calibrationManager->onDeviceConnectionStateChanged(true);
     }
     updateDeviceList();
     on_set_pushButton_clicked();
@@ -1162,6 +1163,7 @@ void MainWindow::onDeviceDisconnected()
     // for the next device (or via the persisted mode if reconnected).
     if (m_calibrationManager) {
         m_calibrationManager->setActiveConceptRfDevice(nullptr);
+        m_calibrationManager->onDeviceConnectionStateChanged(false);
     }
     updateDeviceList();
 }

--- a/translations/qtrfpowermeter_en_US.ts
+++ b/translations/qtrfpowermeter_en_US.ts
@@ -201,7 +201,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="23"/>
-        <location filename="../src/calibrationmanager.cpp" line="976"/>
+        <location filename="../src/calibrationmanager.cpp" line="1013"/>
         <source>Calibration is disabled for this device.</source>
         <translation></translation>
     </message>
@@ -318,13 +318,13 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="401"/>
-        <location filename="../src/calibrationmanager.cpp" line="1162"/>
+        <location filename="../src/calibrationmanager.cpp" line="1202"/>
         <source>Connect</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="408"/>
-        <location filename="../src/calibrationmanager.cpp" line="1163"/>
+        <location filename="../src/calibrationmanager.cpp" line="1203"/>
         <source>not connected</source>
         <translation></translation>
     </message>
@@ -335,9 +335,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="421"/>
-        <location filename="../src/calibrationmanager.cpp" line="1173"/>
-        <location filename="../src/calibrationmanager.cpp" line="1316"/>
-        <location filename="../src/calibrationmanager.cpp" line="1365"/>
+        <location filename="../src/calibrationmanager.cpp" line="126"/>
         <source>Calibrate All</source>
         <translation></translation>
     </message>
@@ -363,235 +361,234 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="600"/>
+        <location filename="../src/calibrationmanager.cpp" line="626"/>
         <source>Invalid Step</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="600"/>
+        <location filename="../src/calibrationmanager.cpp" line="626"/>
         <source>Frequency step must be greater than zero.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="605"/>
+        <location filename="../src/calibrationmanager.cpp" line="631"/>
         <source>Invalid Range</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="605"/>
+        <location filename="../src/calibrationmanager.cpp" line="631"/>
         <source>Start frequency must be less than end frequency.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="625"/>
+        <location filename="../src/calibrationmanager.cpp" line="651"/>
         <source>Invalid power axis</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="626"/>
+        <location filename="../src/calibrationmanager.cpp" line="652"/>
         <source>Min must be less than Max.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="652"/>
-        <location filename="../src/calibrationmanager.cpp" line="681"/>
+        <location filename="../src/calibrationmanager.cpp" line="685"/>
+        <location filename="../src/calibrationmanager.cpp" line="716"/>
         <source>No Selection</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="653"/>
+        <location filename="../src/calibrationmanager.cpp" line="686"/>
         <source>Please pick a cell in the Advanced grid first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="657"/>
-        <location filename="../src/calibrationmanager.cpp" line="689"/>
-        <location filename="../src/calibrationmanager.cpp" line="1263"/>
+        <location filename="../src/calibrationmanager.cpp" line="691"/>
+        <location filename="../src/calibrationmanager.cpp" line="725"/>
+        <location filename="../src/calibrationmanager.cpp" line="1305"/>
         <source>TinySa not connected</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="658"/>
-        <location filename="../src/calibrationmanager.cpp" line="690"/>
-        <location filename="../src/calibrationmanager.cpp" line="1264"/>
+        <location filename="../src/calibrationmanager.cpp" line="692"/>
+        <location filename="../src/calibrationmanager.cpp" line="726"/>
+        <location filename="../src/calibrationmanager.cpp" line="1306"/>
         <source>Please connect the TinySa first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="681"/>
+        <location filename="../src/calibrationmanager.cpp" line="716"/>
         <source>Please select a frequency in the table first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="758"/>
+        <location filename="../src/calibrationmanager.cpp" line="795"/>
         <source>Invalid Name</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="758"/>
+        <location filename="../src/calibrationmanager.cpp" line="795"/>
         <source>Please enter a profile name.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="767"/>
-        <location filename="../src/calibrationmanager.cpp" line="817"/>
+        <location filename="../src/calibrationmanager.cpp" line="804"/>
+        <location filename="../src/calibrationmanager.cpp" line="854"/>
         <source>Success</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="767"/>
+        <location filename="../src/calibrationmanager.cpp" line="804"/>
         <source>Profile &apos;%1&apos; saved.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="823"/>
+        <location filename="../src/calibrationmanager.cpp" line="860"/>
         <source>Error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="962"/>
+        <location filename="../src/calibrationmanager.cpp" line="999"/>
         <source>ConceptRF applies factory calibration internally; user calibration off.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1142"/>
+        <location filename="../src/calibrationmanager.cpp" line="1182"/>
         <source>Pick a port first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1145"/>
+        <location filename="../src/calibrationmanager.cpp" line="1185"/>
         <source>Connecting to %1...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1152"/>
+        <location filename="../src/calibrationmanager.cpp" line="1192"/>
         <source>Disconnect</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1154"/>
+        <location filename="../src/calibrationmanager.cpp" line="1194"/>
         <source>connected: %1 -- connect TinySa RF OUT to the power meter input via coax</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1178"/>
+        <location filename="../src/calibrationmanager.cpp" line="1219"/>
         <source>error: %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1223"/>
+        <location filename="../src/calibrationmanager.cpp" line="1264"/>
         <source>cell %1/%2: no signal (skipped)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1226"/>
+        <location filename="../src/calibrationmanager.cpp" line="1267"/>
         <source>row %1: no signal (skipped)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1244"/>
+        <location filename="../src/calibrationmanager.cpp" line="1286"/>
         <source>clamp at %1 Hz: asked %2 dBm -&gt; %3 dBm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1274"/>
-        <location filename="../src/calibrationmanager.cpp" line="1294"/>
+        <location filename="../src/calibrationmanager.cpp" line="1317"/>
+        <location filename="../src/calibrationmanager.cpp" line="1338"/>
         <source>nothing to calibrate</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1278"/>
-        <location filename="../src/calibrationmanager.cpp" line="1298"/>
+        <location filename="../src/calibrationmanager.cpp" line="126"/>
         <source>Cancel calibration</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1317"/>
+        <location filename="../src/calibrationmanager.cpp" line="1362"/>
         <source>calibration cancelled</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1366"/>
+        <location filename="../src/calibrationmanager.cpp" line="1444"/>
         <source>calibration sweep done</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1412"/>
+        <location filename="../src/calibrationmanager.cpp" line="1495"/>
         <source> (cell %1/%2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1416"/>
+        <location filename="../src/calibrationmanager.cpp" line="1499"/>
         <source>setting %1 MHz / %2 dBm%3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1420"/>
+        <location filename="../src/calibrationmanager.cpp" line="1503"/>
         <source>setting %1 MHz / %2 dBm (asked %3, clamped to band)%4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1475"/>
+        <location filename="../src/calibrationmanager.cpp" line="1559"/>
         <source>setting %1 MHz / %2 dBm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1478"/>
+        <location filename="../src/calibrationmanager.cpp" line="1562"/>
         <source>setting %1 MHz / %2 dBm (asked %3, clamped to band)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1559"/>
+        <location filename="../src/calibrationmanager.cpp" line="1644"/>
         <source>Correction at %1 dBm (dB)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1561"/>
+        <location filename="../src/calibrationmanager.cpp" line="1646"/>
         <source>Correction (dB)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="812"/>
+        <location filename="../src/calibrationmanager.cpp" line="849"/>
         <source>Confirm Delete</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="135"/>
+        <location filename="../src/calibrationmanager.cpp" line="151"/>
         <source>Power axis (dBm):</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="136"/>
+        <location filename="../src/calibrationmanager.cpp" line="152"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="142"/>
+        <location filename="../src/calibrationmanager.cpp" line="158"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="148"/>
+        <location filename="../src/calibrationmanager.cpp" line="164"/>
         <source>Step</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="157"/>
+        <location filename="../src/calibrationmanager.cpp" line="173"/>
         <source>Apply axis</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="812"/>
+        <location filename="../src/calibrationmanager.cpp" line="849"/>
         <source>Are you sure you want to delete the profile &apos;%1&apos;?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="817"/>
+        <location filename="../src/calibrationmanager.cpp" line="854"/>
         <source>Profile &apos;%1&apos; deleted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="823"/>
+        <location filename="../src/calibrationmanager.cpp" line="860"/>
         <source>Could not delete profile &apos;%1&apos;.</source>
         <translation></translation>
     </message>
@@ -1133,7 +1130,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     <message>
         <location filename="../src/mainwindow.ui" line="316"/>
         <location filename="../src/mainwindow.cpp" line="192"/>
-        <location filename="../src/mainwindow.cpp" line="1472"/>
+        <location filename="../src/mainwindow.cpp" line="1474"/>
         <source>Attenuation:</source>
         <translation></translation>
     </message>
@@ -1352,22 +1349,22 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1285"/>
+        <location filename="../src/mainwindow.cpp" line="1287"/>
         <source>Connected to %1 on %2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
+        <location filename="../src/mainwindow.cpp" line="1562"/>
         <source>No Device Selected</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
+        <location filename="../src/mainwindow.cpp" line="1562"/>
         <source>Please select a device type first.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1291"/>
+        <location filename="../src/mainwindow.cpp" line="1293"/>
         <source>Error: %1</source>
         <translation></translation>
     </message>
@@ -1422,7 +1419,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1295"/>
+        <location filename="../src/mainwindow.cpp" line="1297"/>
         <source>Disconnected</source>
         <translation></translation>
     </message>

--- a/translations/qtrfpowermeter_uk_UA.ts
+++ b/translations/qtrfpowermeter_uk_UA.ts
@@ -201,7 +201,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="23"/>
-        <location filename="../src/calibrationmanager.cpp" line="976"/>
+        <location filename="../src/calibrationmanager.cpp" line="1013"/>
         <source>Calibration is disabled for this device.</source>
         <translation>Калібрування вимкнено для цього пристрою.</translation>
     </message>
@@ -318,13 +318,13 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="401"/>
-        <location filename="../src/calibrationmanager.cpp" line="1162"/>
+        <location filename="../src/calibrationmanager.cpp" line="1202"/>
         <source>Connect</source>
         <translation>З&apos;єднати</translation>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="408"/>
-        <location filename="../src/calibrationmanager.cpp" line="1163"/>
+        <location filename="../src/calibrationmanager.cpp" line="1203"/>
         <source>not connected</source>
         <translation>не з&apos;єднано</translation>
     </message>
@@ -335,9 +335,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     </message>
     <message>
         <location filename="../src/calibrationmanager.ui" line="421"/>
-        <location filename="../src/calibrationmanager.cpp" line="1173"/>
-        <location filename="../src/calibrationmanager.cpp" line="1316"/>
-        <location filename="../src/calibrationmanager.cpp" line="1365"/>
+        <location filename="../src/calibrationmanager.cpp" line="126"/>
         <source>Calibrate All</source>
         <translation>Калібрувати все</translation>
     </message>
@@ -363,235 +361,234 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
         <translation>Калібрувати обране</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="600"/>
+        <location filename="../src/calibrationmanager.cpp" line="626"/>
         <source>Invalid Step</source>
         <translation>Некоректний крок</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="600"/>
+        <location filename="../src/calibrationmanager.cpp" line="626"/>
         <source>Frequency step must be greater than zero.</source>
         <translation>Крок частоти має бути більшим за 0.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="605"/>
+        <location filename="../src/calibrationmanager.cpp" line="631"/>
         <source>Invalid Range</source>
         <translation>Некоректний діапазон</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="605"/>
+        <location filename="../src/calibrationmanager.cpp" line="631"/>
         <source>Start frequency must be less than end frequency.</source>
         <translation>Початкова частота має бути більшою за кінцеву.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="625"/>
+        <location filename="../src/calibrationmanager.cpp" line="651"/>
         <source>Invalid power axis</source>
         <translation>Невалідна вісь потужності</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="626"/>
+        <location filename="../src/calibrationmanager.cpp" line="652"/>
         <source>Min must be less than Max.</source>
         <translation>Мін має бути меншим за макс.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="652"/>
-        <location filename="../src/calibrationmanager.cpp" line="681"/>
+        <location filename="../src/calibrationmanager.cpp" line="685"/>
+        <location filename="../src/calibrationmanager.cpp" line="716"/>
         <source>No Selection</source>
         <translation>Нічого не обрано</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="653"/>
+        <location filename="../src/calibrationmanager.cpp" line="686"/>
         <source>Please pick a cell in the Advanced grid first.</source>
         <translation>Будь ласка спочатку оберіть комірку в просунутій таблиці.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="657"/>
-        <location filename="../src/calibrationmanager.cpp" line="689"/>
-        <location filename="../src/calibrationmanager.cpp" line="1263"/>
+        <location filename="../src/calibrationmanager.cpp" line="691"/>
+        <location filename="../src/calibrationmanager.cpp" line="725"/>
+        <location filename="../src/calibrationmanager.cpp" line="1305"/>
         <source>TinySa not connected</source>
         <translation>TinySa не з&apos;єднаний</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="658"/>
-        <location filename="../src/calibrationmanager.cpp" line="690"/>
-        <location filename="../src/calibrationmanager.cpp" line="1264"/>
+        <location filename="../src/calibrationmanager.cpp" line="692"/>
+        <location filename="../src/calibrationmanager.cpp" line="726"/>
+        <location filename="../src/calibrationmanager.cpp" line="1306"/>
         <source>Please connect the TinySa first.</source>
         <translation>Будь ласка спершу приєднайте TinySa.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="681"/>
+        <location filename="../src/calibrationmanager.cpp" line="716"/>
         <source>Please select a frequency in the table first.</source>
         <translation>Будь ласка спочатку оберіть частоту з таблиці.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="758"/>
+        <location filename="../src/calibrationmanager.cpp" line="795"/>
         <source>Invalid Name</source>
         <translation>Некоректне ім&apos;я</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="758"/>
+        <location filename="../src/calibrationmanager.cpp" line="795"/>
         <source>Please enter a profile name.</source>
         <translation>Будь ласка введіть ім&apos;я профілю.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="767"/>
-        <location filename="../src/calibrationmanager.cpp" line="817"/>
+        <location filename="../src/calibrationmanager.cpp" line="804"/>
+        <location filename="../src/calibrationmanager.cpp" line="854"/>
         <source>Success</source>
         <translation>Успішно</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="767"/>
+        <location filename="../src/calibrationmanager.cpp" line="804"/>
         <source>Profile &apos;%1&apos; saved.</source>
         <translation>Профіль &apos;%1&apos; збережено.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="823"/>
+        <location filename="../src/calibrationmanager.cpp" line="860"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="962"/>
+        <location filename="../src/calibrationmanager.cpp" line="999"/>
         <source>ConceptRF applies factory calibration internally; user calibration off.</source>
         <translation>ConceptRF використовує внтрішнє заводське калібрування; користувацьке калібрування вимкнене.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1142"/>
+        <location filename="../src/calibrationmanager.cpp" line="1182"/>
         <source>Pick a port first.</source>
         <translation>Оберіть спочатку порт.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1145"/>
+        <location filename="../src/calibrationmanager.cpp" line="1185"/>
         <source>Connecting to %1...</source>
         <translation>З&apos;єднання з %1...</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1152"/>
+        <location filename="../src/calibrationmanager.cpp" line="1192"/>
         <source>Disconnect</source>
         <translation>Від&apos;єднати</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1154"/>
+        <location filename="../src/calibrationmanager.cpp" line="1194"/>
         <source>connected: %1 -- connect TinySa RF OUT to the power meter input via coax</source>
         <translation>З&apos;єднано: %1 -- з&apos;єднайте TinySa RF OUT до входу вимірювача потужності коаксіальним кабелем</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1178"/>
+        <location filename="../src/calibrationmanager.cpp" line="1219"/>
         <source>error: %1</source>
         <translation>помилка: %1</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1223"/>
+        <location filename="../src/calibrationmanager.cpp" line="1264"/>
         <source>cell %1/%2: no signal (skipped)</source>
         <translation>комірка %1/%2: сигнал відсутній (пропущено)</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1226"/>
+        <location filename="../src/calibrationmanager.cpp" line="1267"/>
         <source>row %1: no signal (skipped)</source>
         <translation>рядок %1: сигнал відсутній (пропущено)</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1244"/>
+        <location filename="../src/calibrationmanager.cpp" line="1286"/>
         <source>clamp at %1 Hz: asked %2 dBm -&gt; %3 dBm</source>
         <translation>фіксування на %1 Hz: запит %2 dBm -&gt; %3 dBm</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1274"/>
-        <location filename="../src/calibrationmanager.cpp" line="1294"/>
+        <location filename="../src/calibrationmanager.cpp" line="1317"/>
+        <location filename="../src/calibrationmanager.cpp" line="1338"/>
         <source>nothing to calibrate</source>
         <translation>нічого калібрувати</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1278"/>
-        <location filename="../src/calibrationmanager.cpp" line="1298"/>
+        <location filename="../src/calibrationmanager.cpp" line="126"/>
         <source>Cancel calibration</source>
         <translation>Скасувати калібрування</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1317"/>
+        <location filename="../src/calibrationmanager.cpp" line="1362"/>
         <source>calibration cancelled</source>
         <translation>калібрування скасовано</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1366"/>
+        <location filename="../src/calibrationmanager.cpp" line="1444"/>
         <source>calibration sweep done</source>
         <translation>пробіг калібрування закінчено</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1412"/>
+        <location filename="../src/calibrationmanager.cpp" line="1495"/>
         <source> (cell %1/%2)</source>
         <translation> (комірка %1/%2)</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1416"/>
+        <location filename="../src/calibrationmanager.cpp" line="1499"/>
         <source>setting %1 MHz / %2 dBm%3</source>
         <translation>встановлення %1 MHz / %2 dBm%3</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1420"/>
+        <location filename="../src/calibrationmanager.cpp" line="1503"/>
         <source>setting %1 MHz / %2 dBm (asked %3, clamped to band)%4</source>
         <translation>встановлення %1 MHz / %2 dBm (запит %3, фіксування на смузі)%4</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1475"/>
+        <location filename="../src/calibrationmanager.cpp" line="1559"/>
         <source>setting %1 MHz / %2 dBm</source>
         <translation>встановлення %1 MHz / %2 dBm</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1478"/>
+        <location filename="../src/calibrationmanager.cpp" line="1562"/>
         <source>setting %1 MHz / %2 dBm (asked %3, clamped to band)</source>
         <translation>встановлення %1 MHz / %2 dBm (запит %3, фіксування на смузі)</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1559"/>
+        <location filename="../src/calibrationmanager.cpp" line="1644"/>
         <source>Correction at %1 dBm (dB)</source>
         <translation>Корекція на %1 dBm (dB)</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="1561"/>
+        <location filename="../src/calibrationmanager.cpp" line="1646"/>
         <source>Correction (dB)</source>
         <translation>Корекція (dB)</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="812"/>
+        <location filename="../src/calibrationmanager.cpp" line="849"/>
         <source>Confirm Delete</source>
         <translation>Підтвердіть видалення</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="135"/>
+        <location filename="../src/calibrationmanager.cpp" line="151"/>
         <source>Power axis (dBm):</source>
         <translation>Вісь потужності (dBm):</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="136"/>
+        <location filename="../src/calibrationmanager.cpp" line="152"/>
         <source>Min</source>
         <translation>Мін</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="142"/>
+        <location filename="../src/calibrationmanager.cpp" line="158"/>
         <source>Max</source>
         <translation>Макс</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="148"/>
+        <location filename="../src/calibrationmanager.cpp" line="164"/>
         <source>Step</source>
         <translation>Крок</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="157"/>
+        <location filename="../src/calibrationmanager.cpp" line="173"/>
         <source>Apply axis</source>
         <translation>Застосувати вісь</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="812"/>
+        <location filename="../src/calibrationmanager.cpp" line="849"/>
         <source>Are you sure you want to delete the profile &apos;%1&apos;?</source>
         <translation>Ви впевнені, що бжаєте видалити профіль &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="817"/>
+        <location filename="../src/calibrationmanager.cpp" line="854"/>
         <source>Profile &apos;%1&apos; deleted.</source>
         <translation>Профіль &apos;%1&apos; видалено.</translation>
     </message>
     <message>
-        <location filename="../src/calibrationmanager.cpp" line="823"/>
+        <location filename="../src/calibrationmanager.cpp" line="860"/>
         <source>Could not delete profile &apos;%1&apos;.</source>
         <translation>Неможливо видалити  профіль&apos;%1&apos;.</translation>
     </message>
@@ -1133,7 +1130,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
     <message>
         <location filename="../src/mainwindow.ui" line="316"/>
         <location filename="../src/mainwindow.cpp" line="192"/>
-        <location filename="../src/mainwindow.cpp" line="1472"/>
+        <location filename="../src/mainwindow.cpp" line="1474"/>
         <source>Attenuation:</source>
         <translation>Послаблення:</translation>
     </message>
@@ -1352,22 +1349,22 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
         <translation>Калькулятор втрат коаксіального кабелю</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1285"/>
+        <location filename="../src/mainwindow.cpp" line="1287"/>
         <source>Connected to %1 on %2</source>
         <translation>З&apos;єднано з %1 по %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
+        <location filename="../src/mainwindow.cpp" line="1562"/>
         <source>No Device Selected</source>
         <translation>Пристрій не обрано</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
+        <location filename="../src/mainwindow.cpp" line="1562"/>
         <source>Please select a device type first.</source>
         <translation>Будь ласка спочатку оберіть тип пристрою.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1291"/>
+        <location filename="../src/mainwindow.cpp" line="1293"/>
         <source>Error: %1</source>
         <translation>Помилка: %1</translation>
     </message>
@@ -1422,7 +1419,7 @@ beyond the cable&apos;s min data frequency of %1 MHz.</source>
         <translation>Графік збережено → %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1295"/>
+        <location filename="../src/mainwindow.cpp" line="1297"/>
         <source>Disconnected</source>
         <translation>Від&apos;єднано</translation>
     </message>


### PR DESCRIPTION
This pull request significantly improves the calibration workflow in the `CalibrationManager` by making the calibrate buttons' enabled and checked states more robust and context-aware. It introduces a new helper method to centralize button state logic, ensures UI consistency during calibration operations, and enhances user feedback by scrolling to the relevant table cell during calibration sweeps. These changes help prevent invalid calibration actions and make the calibration process clearer for users.

**Calibration button state management:**

* Added a new `refreshButtonEnabledState()` helper that centralizes the logic for enabling/disabling the `pickAverageButton` and `calibrateAllButton` based on device connection status, calibration mode, and table selection. This replaces scattered manual enable/disable calls and ensures consistent button states throughout the UI. [[1]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1399-R1431) [[2]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L222-R246) [[3]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L639-R693) [[4]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L1084-R1125) [[5]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L1156-R1204) [[6]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L94)
* Both calibrate buttons are now checkable, and their checked state is used to indicate when a calibration is in progress. The table views are automatically disabled ("greyed out") during calibration, improving clarity and preventing accidental edits.

**Calibration operation and UI feedback improvements:**

* The calibrate buttons are now programmatically unchecked when calibration is cancelled, completed, or cannot start due to missing prerequisites (e.g., no device connected, no selection). This prevents the UI from getting out of sync with the actual calibration state. [[1]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R552-R560) [[2]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R607) [[3]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1275) [[4]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1307) [[5]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1318-R1322) [[6]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1339-R1343) [[7]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L1316-R1361) [[8]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L1365-R1443) [[9]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L1173-R1214)
* Added guard logic to prevent starting a new calibration if one is already running, and to reset button state if the user attempts invalid actions (e.g., clicking without a selection or device connection). [[1]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505L639-R693) [[2]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R717) [[3]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R727)

**User experience enhancements:**

* Introduced `scrollToCurrentAutoCell()` to automatically select and scroll the table to the cell being calibrated during auto sweeps, making progress visible to the user. [[1]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1471-R1475) [[2]](diffhunk://#diff-0fe8fa8884a0b2c018fab9488704131aa702e78a8dd3c6090503497a120dd505R1543) [[3]](diffhunk://#diff-204d07489af7f076f9535fcb723728853c40f4503a1d2d079bd93aa7ee5655d1R123-R128)
* Updated translation source line numbers to match code changes. [[1]](diffhunk://#diff-ecd4aa7f75459af2133e41ac76b62a4ff954ae58bb6490d0a6ea5a144f292f45L204-R204) [[2]](diffhunk://#diff-ecd4aa7f75459af2133e41ac76b62a4ff954ae58bb6490d0a6ea5a144f292f45L321-R327)

**Integration with device connection events:**

* Ensured that calibration button states are updated in response to device connection and disconnection events by calling `onDeviceConnectionStateChanged()` from the main window. [[1]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R1148) [[2]](diffhunk://#diff-c72b037f3ac7abbd3d0ee519b6f456013a9bbf5a59df16308939320c04970447R1166)

**Internal state tracking:**

* Added a new `m_pmConnected` member to track the power meter connection state, used by the new button state logic.